### PR TITLE
Fix code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export default Ember.Component.extend({
     {
       title:"marker1",
       description:"this is marker1",
-      location: L.LatLng(53.318602,48.586415)
+      location: new L.LatLng(53.318602,48.586415)
     }
   ],
   polylines:[


### PR DESCRIPTION
The Leaflet `L.LatLng()` function sets the `lat` and `lng` functions on itself, then returns `undefined`.
This causes ember to throw and error, because `location` is a required parameter, and it is being set to `undefined`.
To get the actual created `LatLng` object, we need to use `new L.LatLng()`.
This change is tested and working on Ember 2.8, and Leaflet 3.0.1
