### PR TITLE
Fix for using ember-leaflet-layer-control on ember-leaflet 3.0.2 (and 3.0.3) which uses ember-composibility-tools

### DIFF
--- a/addon/components/layer-control.js
+++ b/addon/components/layer-control.js
@@ -1,49 +1,49 @@
 import Ember from 'ember';
 import BaseLayer from 'ember-leaflet/components/base-layer';
-
-const {get,isEmpty,isBlank,isEqual} = Ember;
+const {get,isEmpty,isBlank} = Ember;
 
 export default BaseLayer.extend({
-  	layerSetup() {
-	    this._layer = this.createLayer();
-	    this._addObservers();
-	    this._addEventListeners();
-	    if (get(this,'containerLayer')) {
-	    	this._layer.addTo(get(this,'containerLayer')._layer);
-	    }
-	    this.didCreateLayer();
-  	},
-  	createLayer(){
-  		return L.control.layers();
-  	},
-  	didCreateLayer(){
-  		let layerGroups = get(this,'containerLayer._layerGroups');
-  		if (!isBlank(layerGroups)){
-        layerGroups.forEach(layerGroup=>{
-          if (layerGroup.default){
-            let containerLayer = get(this,'containerLayer._layer');
-            layerGroup.layer.addTo(containerLayer);
-          }
-          this._layer.addOverlay(layerGroup.layer,layerGroup.name);
-        });
-      }
-      let baseLayers = get(this,'containerLayer._baseLayers');
-      if (!isBlank(baseLayers)){
-        baseLayers.forEach(baseLayer=>{
-          if (baseLayer.default){
-            let containerLayer = get(this,'containerLayer._layer');
-            baseLayer.layer.addTo(containerLayer);
-          }
-          this._layer.addBaseLayer(baseLayer.layer,baseLayer.name);
-        });
-      }
-      
-      let handler = get(this,'handler') || null;
-      if (!isEmpty(handler)){
-        let map = get(this,'containerLayer')._layer;
-        map.on('overlayadd', this.attrs.handler);
-        map.on('overlayremove', this.attrs.handler);
-        map.on('baselayerchange', this.attrs.handler);
-      }
-  	}
+  didInsertParent() {
+    this._layer = this.createLayer();
+    this._addObservers();
+    this._addEventListeners();
+    if (get(this,'parentComponent')) {
+      this._layer.addTo(get(this,'parentComponent')._layer);
+    }
+    this.didCreateLayer();
+  },
+  createLayer(){
+    return L.control.layers();
+  },
+  didCreateLayer() {
+    this._super(...arguments);
+    var layerGroups = get(this,'parentComponent._layerGroups');
+    if (!isBlank(layerGroups)){
+      layerGroups.forEach(layerGroup=>{
+        if (layerGroup.default){
+          let containerLayer = get(this,'parentComponent._layer');
+          layerGroup.layer.addTo(containerLayer);
+        }
+        this._layer.addOverlay(layerGroup.layer,layerGroup.name);
+      });
+    }
+    let baseLayers = get(this,'parentComponent._baseLayers');
+    if (!isBlank(baseLayers)){
+      baseLayers.forEach(baseLayer=>{
+        if (baseLayer.default){
+          let containerLayer = get(this,'parentComponent._layer');
+          baseLayer.layer.addTo(containerLayer);
+        }
+        this._layer.addBaseLayer(baseLayer.layer,baseLayer.name);
+      });
+    }
+
+    let handler = get(this,'handler') || null;
+    if (!isEmpty(handler)){
+      let map = get(this,'parentComponent')._layer;
+      map.on('overlayadd', this.attrs.handler);
+      map.on('overlayremove', this.attrs.handler);
+      map.on('baselayerchange', this.attrs.handler);
+    }
+  }
 });

--- a/addon/components/layer-control.js
+++ b/addon/components/layer-control.js
@@ -12,29 +12,30 @@ export default BaseLayer.extend({
     }
     this.didCreateLayer();
   },
-  createLayer(){
-    return L.control.layers();
+  createLayer() {
+    //L is defined globally by Leaflet
+    return L.control.layers(); // jshint ignore:line
   },
   didCreateLayer() {
     this._super(...arguments);
     var layerGroups = get(this,'parentComponent._layerGroups');
     if (!isBlank(layerGroups)){
-      layerGroups.forEach(layerGroup=>{
+      layerGroups.forEach(layerGroup => {
         if (layerGroup.default){
-          let containerLayer = get(this,'parentComponent._layer');
-          layerGroup.layer.addTo(containerLayer);
+          let parentLayer = get(this,'parentComponent._layer');
+          layerGroup.layer.addTo(parentLayer);
         }
-        this._layer.addOverlay(layerGroup.layer,layerGroup.name);
+        this._layer.addOverlay(layerGroup.layer, layerGroup.name);
       });
     }
     let baseLayers = get(this,'parentComponent._baseLayers');
     if (!isBlank(baseLayers)){
       baseLayers.forEach(baseLayer=>{
         if (baseLayer.default){
-          let containerLayer = get(this,'parentComponent._layer');
-          baseLayer.layer.addTo(containerLayer);
+          let parentLayer = get(this,'parentComponent._layer');
+          baseLayer.layer.addTo(parentLayer);
         }
-        this._layer.addBaseLayer(baseLayer.layer,baseLayer.name);
+        this._layer.addBaseLayer(baseLayer.layer, baseLayer.name);
       });
     }
 

--- a/addon/components/layer-group.js
+++ b/addon/components/layer-group.js
@@ -1,77 +1,85 @@
 import Ember from 'ember';
 import BaseLayer from 'ember-leaflet/components/base-layer';
-import ContainerMixin from 'ember-leaflet/mixins/container';
+import { ParentMixin } from 'ember-composability-tools';
 
-const {get, getProperties, isEmpty, set, isNone} = Ember;
+const {get, isEmpty, set, isNone} = Ember;
 
-export default BaseLayer.extend(ContainerMixin,{
-	baselayer: false,
-	blockLayer: false,
-	default: false,
-	createLayer(){
-		return this.L.layerGroup();
-	},
-	didInsertElement() {
-		this._super(...arguments);
-		this.layerSetup();
-		this.get('_childLayers').invoke('layerSetup');
-		this.registerNameOnParent();
-	},
-	registerNameOnParent(){
-		let name = get(this,'name');
-		let container = this.get('containerLayer');
-		let defaultState = get(this,'default');
-		if (!get(this,'baselayer')){
-			let layerGroups = get(container,'_layerGroups');
-			if (isEmpty(layerGroups)){
-				layerGroups = Ember.A();
-				set(container,'_layerGroups',layerGroups);
-			} 
-			layerGroups.addObject({
-				name:name,
-				layer:get(this,'_layer'),
-				default: defaultState
-			});
-		} else {
-			let baseLayers = get(container,'_baseLayers');
-			if (isEmpty(baseLayers)){
-				baseLayers = Ember.A();
-				set(container,'_baseLayers',baseLayers);
-			}
-			baseLayers.addObject({
-				name:name, 
-				layer:get(this,'_layer._layer'),
-				default: defaultState
-			});
-		}
-	},
-	willDestroyLayer() {
-		this.get('_childLayers').invoke('layerTeardown');
-		this.get('_childLayers').clear();
-	},
-	layerSetup() {
-		if (isNone(get(this,'_layer'))) {
-			if (!get(this,'baselayer')){
-				set(this,'blockLayer',true);
-				this._layer = this.createLayer();
-				this.didCreateLayer();
-				if (get(this,'containerLayer')) {
-					if (!isNone(get(this,'containerLayer')._layer)) {
-						get(this,'containerLayer')._layer.addLayer(this._layer);
-					}
-				}
-			} else {
-				this._layer = {
-					_layer: null,
-					addLayer(layer){
-						this._layer = layer;
-					},
-					removeLayer(){
-						this._layer = null;
-					}
-				};
-			}
-		}
-		
+export default BaseLayer.extend(ParentMixin, {
+  baselayer: false,
+  blockLayer: false,
+  default: false,
+  createLayer(){
+    return this.L.layerGroup();
+  },
+
+  registerNameOnParent(){
+    let name = get(this,'name');
+    let container = this.get('parentComponent');
+    let defaultState = get(this,'default');
+    if (!get(this,'baselayer')){
+      let layerGroups = get(container,'_layerGroups');
+      if (isEmpty(layerGroups)){
+        layerGroups = Ember.A();
+        set(container,'_layerGroups',layerGroups);
+      }
+      layerGroups.addObject({
+        name:name,
+        layer:get(this,'_layer'),
+        default: defaultState
+      });
+    } else {
+      let baseLayers = get(container,'_baseLayers');
+      if (isEmpty(baseLayers)){
+        baseLayers = Ember.A();
+        set(container,'_baseLayers',baseLayers);
+      }
+      baseLayers.addObject({
+        name:name,
+        layer:get(this,'_layer._layer'),
+        default: defaultState
+      });
     }
+  },
+
+  didInsertParent() {
+    if (isNone(get(this,'_layer'))) {
+      if (!get(this,'baselayer')){
+        set(this,'blockLayer',true);
+        this._layer = this.createLayer();
+        if (get(this,'parentComponent')) {
+          if (!isNone(get(this,'parentComponent')._layer)) {
+            this.addToContainer();
+          }
+        }
+      } else {
+        this._layer = {
+          _layer: null,
+          addLayer(layer){
+            this._layer = layer;
+          },
+          removeLayer(){
+            this._layer = null;
+          }
+        };
+      }
+      this.didCreateLayer();
+    }
+  },
+
+  didCreateLayer() {
+    this._super(...arguments);
+    var invokeChildDidInsertHooks = get(this, 'invokeChildDidInsertHooks');
+    /* create the children of this layer group early, so they exist when we run registerNameOnParent */
+    invokeChildDidInsertHooks.call(this);
+  },
+
+  invokeChildDidInsertHooks() {
+    var insertedChildren = get(this, 'insertedChildren');
+    if (!insertedChildren) {
+      this._super(...arguments);
+      this.registerNameOnParent();
+      set(this, 'insertedChildren', true);
+    }
+  }
+
 });

--- a/package.json
+++ b/package.json
@@ -48,8 +48,9 @@
     "leaflet"
   ],
   "dependencies": {
+    "ember-cli-htmlbars": "^1.0.1",
     "ember-composability-tools": "~0.0.3",
-    "ember-leaflet": "~3.0.3"
+    "ember-leaflet": "~3.0.5"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
+    "ember-cli-babel": "^5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
@@ -47,10 +48,8 @@
     "leaflet"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1",
-    "ember-composability-tools": "~0.0.2",
-    "ember-leaflet": "^2.2.0"
+    "ember-composability-tools": "~0.0.3",
+    "ember-leaflet": "~3.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.1.2",
-    "loader.js": "^4.0.0",
-    "ember-leaflet": "^2.2.0"
+    "loader.js": "^4.0.0"
   },
   "keywords": [
     "ember-addon",
@@ -49,7 +48,9 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-cli-htmlbars": "^1.0.1"
+    "ember-cli-htmlbars": "^1.0.1",
+    "ember-composability-tools": "~0.0.2",
+    "ember-leaflet": "^2.2.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/integration/components/layer-group-test.js
+++ b/tests/integration/components/layer-group-test.js
@@ -55,7 +55,7 @@ test('layer group registers baselayers on parent', function(assert) {
     {{/leaflet-map}}
 
     `);
-  let baseLayers = get(layerGroup,'containerLayer._baseLayers');
+  let baseLayers = get(layerGroup,'parentComponent._baseLayers');
   assert.equal(get(baseLayers,'length'),1);
   assert.equal(get(baseLayers,'firstObject.name'),get(this,'name'));
   assert.equal(get(baseLayers,'firstObject.default'),true);
@@ -77,7 +77,7 @@ test('layer group registers overlays on parent', function(assert) {
     {{/leaflet-map}}
 
     `);
-  let layerGroups = get(layerGroup,'containerLayer._layerGroups');
+  let layerGroups = get(layerGroup,'parentComponent._layerGroups');
   assert.equal(get(layerGroups,'length'),1);
   assert.equal(get(layerGroups,'firstObject.name'),get(this,'name'));
   assert.equal(get(layerGroups,'firstObject.default'),false);


### PR DESCRIPTION
Fix for using ember-leaflet-layer-control on ember-leaflet 3.0.2 which uses ember-composibility-tools
Fixes https://github.com/canufeel/ember-leaflet-layer-control/issues/2
Tested on a minimal ember-cli project, with just ember-leaflet and ember-leaflet-layer-control installed.