### PR TITLE
Add dependency to ember-cli-babel 6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "leaflet"
   ],
   "dependencies": {
+    "ember-cli-babel": "^6.1.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-composability-tools": "~0.0.3",
     "ember-leaflet": "~3.0.5"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.5",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",


### PR DESCRIPTION
This fixes a deprecation warning with recent ember versions and is required when babel 6 is used.