### PR TITLE
Fix zIndex issues for tiles used as overlays

### DIFF
--- a/addon/components/layer-control.js
+++ b/addon/components/layer-control.js
@@ -18,16 +18,6 @@ export default BaseLayer.extend({
   },
   didCreateLayer() {
     this._super(...arguments);
-    var layerGroups = get(this,'parentComponent._layerGroups');
-    if (!isBlank(layerGroups)){
-      layerGroups.forEach(layerGroup => {
-        if (layerGroup.default){
-          let parentLayer = get(this,'parentComponent._layer');
-          layerGroup.layer.addTo(parentLayer);
-        }
-        this._layer.addOverlay(layerGroup.layer, layerGroup.name);
-      });
-    }
     let baseLayers = get(this,'parentComponent._baseLayers');
     if (!isBlank(baseLayers)){
       baseLayers.forEach(baseLayer=>{
@@ -38,7 +28,18 @@ export default BaseLayer.extend({
         this._layer.addBaseLayer(baseLayer.layer, baseLayer.name);
       });
     }
-
+    let layerGroups = get(this,'parentComponent._layerGroups');
+    if (!isBlank(layerGroups)){
+      layerGroups.forEach(layerGroup => {
+        let parentLayer = get(this,'parentComponent._layer');
+        if (layerGroup.default){
+          layerGroup.layer.addTo(parentLayer);
+        } else {
+          layerGroup.layer.removeFrom(parentLayer);
+        }
+        this._layer.addOverlay(layerGroup.layer, layerGroup.name);
+      });
+    }
     let handler = get(this,'handler') || null;
     if (!isEmpty(handler)){
       let map = get(this,'parentComponent')._layer;


### PR DESCRIPTION
This should close issue #9 

Fix zIndex issues for tiles and wms tiles used as overlays. Based on the way these elements make their way into the leaflet map instance, inserting the base maps after overlays causes tile sets being used as overlays to always display behind the basemap. Additionally, the current code forces overlay layers to always be inserted into the map regardless of whether or not default is set to false. This commit resolves these issues.